### PR TITLE
Remove invalid upstreams

### DIFF
--- a/imx-6.12.20-2.0.0.xml
+++ b/imx-6.12.20-2.0.0.xml
@@ -34,11 +34,11 @@
   <project name="meta-timesys" remote="timesys" path="sources/meta-timesys" revision="7e5f4a3436c2acea499349012a46a9215bb9284e" upstream="master" />
   <project name="meta-virtualization" remote="yp" path="sources/meta-virtualization" revision="4fedb61ebf60745a367d857af255006bd3509a39" upstream="walnascar" />
 
-  <project name="meta-imx" remote="imx" path="sources/meta-imx" revision="refs/tags/rel_imx_6.12.20_2.0.0" upstream="walnascar-6.12.20.2.0.0">
+  <project name="meta-imx" remote="imx" path="sources/meta-imx" revision="refs/tags/rel_imx_6.12.20_2.0.0" >
      <linkfile src="tools/imx-setup-release.sh" dest="imx-setup-release.sh" />
      <linkfile src="README" dest="README-IMXBSP" />
   </project>
-  <project name="meta-nxp-connectivity" remote="imx" path="sources/meta-nxp-connectivity" revision="refs/tags/rel_imx_6.12.20_2.0.0" upstream="imx_matter_2025_q1-post" />
-  <project name="meta-nxp-demo-experience" remote="imx-support" path="sources/meta-nxp-demo-experience" revision="refs/tags/rel_imx_6.12.20_2.0.0" upstream="walnascar-6.12.20-2.0.0" />
+  <project name="meta-nxp-connectivity" remote="imx" path="sources/meta-nxp-connectivity" revision="refs/tags/rel_imx_6.12.20_2.0.0" />
+  <project name="meta-nxp-demo-experience" remote="imx-support" path="sources/meta-nxp-demo-experience" revision="refs/tags/rel_imx_6.12.20_2.0.0" />
 
 </manifest>

--- a/imx-6.12.20-2.0.0_harpoon-v3.4.xml
+++ b/imx-6.12.20-2.0.0_harpoon-v3.4.xml
@@ -5,7 +5,7 @@
 
   <remote name="nxp" fetch="https://github.com/NXP"/>
 
-  <project remote="nxp" revision="refs/tags/lf-6.12.20_2.0.0-harpoon-3.4.0" name="meta-nxp-harpoon" path="sources/meta-nxp-harpoon" upstream="imx-linux-walnascar" >
+  <project remote="nxp" revision="refs/tags/lf-6.12.20_2.0.0-harpoon-3.4.0" name="meta-nxp-harpoon" path="sources/meta-nxp-harpoon" >
     <linkfile src="tools/imx-harpoon-setup-release.sh" dest="imx-harpoon-setup-release.sh"/>
   </project>
 

--- a/imx-6.12.20-2.0.0_orangebox.xml
+++ b/imx-6.12.20-2.0.0_orangebox.xml
@@ -3,7 +3,7 @@
 
   <include name="imx-6.12.20-2.0.0.xml"/>
 
-  <project name="meta-imx-orangebox" remote="imx" path="sources/meta-imx-orangebox" revision="refs/tags/rel_imx_6.12.20_2.0.0" upstream="walnascar-6.12.20.2.0.0" />
+  <project name="meta-imx-orangebox" remote="imx" path="sources/meta-imx-orangebox" revision="refs/tags/rel_imx_6.12.20_2.0.0" />
   <project name="meta-imx-scfw" remote="imx" path="sources/meta-imx-scfw" revision="0fb5a355244547cb1576a8e70d8dd0d407134977" upstream="master" />
   <project name="meta-nxp-web-ui" remote="imx" path="sources/meta-nxp-web-ui" revision="5b385935e6bd71a3f4eff9400ffe87df70dfa657" upstream="master" />
 

--- a/imx-6.12.34-2.1.0.xml
+++ b/imx-6.12.34-2.1.0.xml
@@ -33,11 +33,11 @@
   <project name="meta-timesys" remote="timesys" path="sources/meta-timesys"  revision="3c362eeeb68523a88c2301e29ab1fd4802284e50" upstream="master" />
   <project name="meta-virtualization" remote="yp" path="sources/meta-virtualization" revision="898239e810acbb7db93299f20deec8afe434f11b" upstream="walnascar" />
 
-  <project name="meta-imx" remote="imx" path="sources/meta-imx" revision="refs/tags/rel_imx_6.12.34_2.1.0" upstream="walnascar-6.12.34.2.1.0">
+  <project name="meta-imx" remote="imx" path="sources/meta-imx" revision="refs/tags/rel_imx_6.12.34_2.1.0" >
      <linkfile src="tools/imx-setup-release.sh" dest="imx-setup-release.sh" />
      <linkfile src="README.md" dest="README.md" />
   </project>
-  <project name="meta-nxp-connectivity" remote="imx" path="sources/meta-nxp-connectivity" revision="refs/tags/rel_imx_6.12.34_2.1.0" upstream="imx_matter_2025_q1-post" />
-  <project name="meta-nxp-demo-experience" remote="imx-support" path="sources/meta-nxp-demo-experience" revision="refs/tags/rel_imx_6.12.34_2.1.0" upstream="walnascar-6.12.34-2.1.0" />
+  <project name="meta-nxp-connectivity" remote="imx" path="sources/meta-nxp-connectivity" revision="refs/tags/rel_imx_6.12.34_2.1.0" />
+  <project name="meta-nxp-demo-experience" remote="imx-support" path="sources/meta-nxp-demo-experience" revision="refs/tags/rel_imx_6.12.34_2.1.0" />
 
 </manifest>

--- a/imx-6.12.34-2.1.0_orangebox.xml
+++ b/imx-6.12.34-2.1.0_orangebox.xml
@@ -3,7 +3,7 @@
 
   <include name="imx-6.12.34-2.1.0.xml"/>
 
-  <project name="meta-imx-orangebox" remote="imx" path="sources/meta-imx-orangebox" revision="refs/tags/rel_imx_6.12.34_2.1.0" upstream="walnascar-6.12.34.2.1.0" />
+  <project name="meta-imx-orangebox" remote="imx" path="sources/meta-imx-orangebox" revision="refs/tags/rel_imx_6.12.34_2.1.0" />
   <project name="meta-imx-scfw" remote="imx" path="sources/meta-imx-scfw" revision="0fb5a355244547cb1576a8e70d8dd0d407134977" upstream="master" />
   <project name="meta-nxp-web-ui" remote="imx" path="sources/meta-nxp-web-ui" revision="b54a19fdbc79f3310bd3c6e97daa92ff86cf7d2f" upstream="master" />
 


### PR DESCRIPTION
This patch removes upstream attribute for projects, whose revisions points to tag or branch.

Upstream attribute is intended to be used when revision point to hash of commit, to aid the commit search in git.
If revision point to tag, the upstream attribute is not used in case if you just call repo sync.

If you try to pin manifest using `repo manifest -r -o pinned-manifest.xml` it will reuse the upstream without checking.
Which will lead to errors, if upstream attribute is invalid.

When I tried to pin manifest for our project I have discovered that
`<project name="meta-imx" remote="imx" path="sources/meta-imx" revision="refs/tags/rel_imx_6.12.34_2.1.0" upstream="walnascar-6.12.34.2.1.0">`
has invalid upstream and walnascar-6.12.34.2.1.0 doesn't exist. Probably a typo(note the dot-dash difference): walnascar-6.12.34-2.1.0. 

But since upstream shouldn't be there when revision doesn't point to commit hash - let's remove them.